### PR TITLE
PHP 7.2 fixes for count()

### DIFF
--- a/payment/uc_payment/uc_payment.module
+++ b/payment/uc_payment/uc_payment.module
@@ -769,7 +769,7 @@ function uc_payment_load_payments($order_id, $action = NULL) {
 function _payment_method_list($action = NULL) {
   static $methods;
 
-  if (count($methods) > 0 && $action !== 'rebuild') {
+  if (!empty($methods) && $action !== 'rebuild') {
     return $methods;
   }
 

--- a/uc_attribute/uc_attribute.module
+++ b/uc_attribute/uc_attribute.module
@@ -808,7 +808,7 @@ function uc_attribute_load_product_attributes($nid) {
  */
 function uc_attribute_save(&$attribute) {
   // Insert or update?
-  $key = empty($attribute->aid) ? NULL : 'aid';
+  $key = empty($attribute->aid) ? array() : 'aid';
   return drupal_write_record('uc_attributes', $attribute, $key);
 }
 
@@ -859,7 +859,7 @@ function uc_attribute_option_load($oid) {
  */
 function uc_attribute_option_save(&$option) {
   // Insert or update?
-  $key = empty($option->oid) ? NULL : 'oid';
+  $key = empty($option->oid) ? array() : 'oid';
   return drupal_write_record('uc_attribute_options', $option, $key);
 }
 
@@ -904,7 +904,7 @@ function uc_attribute_subject_save(&$attribute, $type, $id, $save_options = FALS
   $sql = uc_attribute_type_info($type);
 
   // Insert or update?
-  $key = uc_attribute_subject_exists($attribute->aid, $type, $id) ? array('aid', $sql['id']) : NULL;
+  $key = uc_attribute_subject_exists($attribute->aid, $type, $id) ? array('aid', $sql['id']) : array();
 
   // First, save the options. First because if this is an insert, we'll set
   // a default option for the product/class attribute.
@@ -1021,7 +1021,7 @@ function uc_attribute_subject_option_save(&$option, $type, $id) {
   $sql = uc_attribute_type_info($type);
 
   // Insert or update?
-  $key = uc_attribute_subject_option_exists($option->oid, $type, $id) ? array('oid', $sql['id']) : NULL;
+  $key = uc_attribute_subject_option_exists($option->oid, $type, $id) ? array('oid', $sql['id']) : array();
 
   // Merge in the product/class attribute option's ID, and save.
   $option->{$type == 'product' ? 'nid' : 'pcid'} = $id;

--- a/uc_cart/uc_cart.module
+++ b/uc_cart/uc_cart.module
@@ -1672,7 +1672,7 @@ function uc_cart_empty($cart_id, $op = 'remove') {
 function uc_cart_cart_pane_list($items, $action = NULL) {
   static $panes;
 
-  if (count($panes) > 0 && $action !== 'rebuild') {
+  if (!empty($panes) && $action !== 'rebuild') {
     return $panes;
   }
 

--- a/uc_cart/uc_cart_checkout_pane.inc
+++ b/uc_cart/uc_cart_checkout_pane.inc
@@ -532,7 +532,7 @@ function _uc_cart_checkout_next_pane($panes, $pane_id = NULL) {
 function _checkout_pane_list($action = NULL) {
   static $panes;
 
-  if (count($panes) > 0 && $action !== 'rebuild') {
+  if (!empty($panes) && $action !== 'rebuild') {
     return $panes;
   }
 

--- a/uc_file/uc_file.module
+++ b/uc_file/uc_file.module
@@ -441,6 +441,7 @@ function theme_uc_file_hook_user_file_downloads($form) {
     array('data' => t('Downloads' )),
     array('data' => t('Addresses' )),
   );
+  $rows = array();
 
   foreach ($form['file_download'] as $key => $data) {
 
@@ -961,7 +962,7 @@ function uc_file_feature_form_submit($form, &$form_state) {
     $file_product['pfid'] = db_last_insert_id('uc_product_features', 'pfid');
   }
 
-  $key = NULL;
+  $key = array();
   if ($fpid = _uc_file_get_fpid($file_product['pfid'])) {
     $key = 'fpid';
     $file_product['fpid'] = $fpid;

--- a/uc_order/uc_order.admin.inc
+++ b/uc_order/uc_order.admin.inc
@@ -249,6 +249,9 @@ function uc_order_workflow_form_submit($form, &$form_state) {
   }
 
   foreach ($form_state['values']['order_statuses'] as $key => $value) {
+    if (!is_array($value)) {
+      continue;
+    }
     if ($value['locked'] != TRUE && $value['remove'] == TRUE) {
       db_query("DELETE FROM {uc_order_statuses} WHERE order_status_id = '%s'", $key);
       drupal_set_message(t('Order status %status removed.', array('%status' => $key)));
@@ -1394,7 +1397,7 @@ function uc_order_edit_products($order) {
  * @see theme_uc_order_remove_product()
  */
 function uc_order_edit_products_form($form_state, $products) {
-  if (($product_count = count($products)) > 0) {
+  if (is_array($products) && ($product_count = count($products)) > 0) {
     $form['products'] = tapir_get_table('op_products_edit_table');
     for ($i = 0; $i < $product_count; $i++) {
       $form['products'][$i]['remove'] = array(

--- a/uc_order/uc_order.line_item.inc
+++ b/uc_order/uc_order.line_item.inc
@@ -155,7 +155,7 @@ function uc_order_line_item_add($order_id, $type, $title, $amount, $weight = NUL
 function _line_item_list($action = NULL) {
   static $items;
 
-  if (count($items) > 0 && $action !== 'rebuild') {
+  if (!empty($items) && $action !== 'rebuild') {
     return $items;
   }
 

--- a/uc_order/uc_order.module
+++ b/uc_order/uc_order.module
@@ -1174,7 +1174,7 @@ function uc_order_product_save($order_id, $product) {
   }
 
   // Update if there is an order_product_id, insert if there isn't.
-  $key = empty($product->order_product_id) ? NULL : 'order_product_id';
+  $key = empty($product->order_product_id) ? array() : 'order_product_id';
   // @TODO order_id should be in the object by this point.
   $product->order_id = $order_id;
   return drupal_write_record('uc_order_products', $product, $key);

--- a/uc_order/uc_order.order_pane.inc
+++ b/uc_order/uc_order.order_pane.inc
@@ -1072,7 +1072,7 @@ function op_admin_comments_view_table($comments) {
 function _order_pane_list($view = 'view') {
   static $panes;
 
-  if (count($panes) > 0) {
+  if (!empty($panes)) {
     return $panes;
   }
 

--- a/uc_roles/uc_roles.module
+++ b/uc_roles/uc_roles.module
@@ -830,7 +830,7 @@ function uc_roles_product_write_record($product_role) {
     $product_role[$property] = $product_role[$property] === NULL ? 0 : $product_role[$property];
   }
 
-  $key = NULL;
+  $key = array();
   if ($product_role['rpid']) {
     $key = 'rpid';
   }


### PR DESCRIPTION
PHP 7.2 fixes for `count()`.
When calling `drupal_write_record()` with `$update` set to `NULL`, Drupal core performs `count($update)` which produces an error. Added a few changes to turn `$update` from `NULL` to `array()`.