### PR TITLE
Backport D7 PayPal IPN fixes #2790197 and #2800003

### DIFF
--- a/payment/uc_paypal/uc_paypal.pages.inc
+++ b/payment/uc_paypal/uc_paypal.pages.inc
@@ -67,10 +67,10 @@ function uc_paypal_ipn() {
   $post_fields[] = 'cmd=_notify-validate';
 
   if (variable_get('uc_paypal_wpp_server', '') == 'https://api-3t.paypal.com/nvp') {
-    $host = 'https://www.paypal.com/cgi-bin/webscr';
+    $host = 'https://ipnpb.paypal.com/cgi-bin/webscr';
   }
   else {
-    $host = variable_get('uc_paypal_wps_server', 'https://www.sandbox.paypal.com/cgi-bin/webscr');
+    $host = variable_get('uc_paypal_wps_server', 'https://ipnpb.sandbox.paypal.com/cgi-bin/webscr');
   }
 
   // Setup the cURL request.

--- a/payment/uc_paypal/uc_paypal.pages.inc
+++ b/payment/uc_paypal/uc_paypal.pages.inc
@@ -60,14 +60,11 @@ function uc_paypal_ipn() {
     return;
   }
 
-  $req = '';
-
   foreach ($_POST as $key => $value) {
-    $value = urlencode(stripslashes($value));
-    $req .= $key .'='. $value .'&';
+    $post_fields[] = $key . '=' . urlencode(stripslashes($value));
   }
 
-  $req .= 'cmd=_notify-validate';
+  $post_fields[] = 'cmd=_notify-validate';
 
   if (variable_get('uc_paypal_wpp_server', '') == 'https://api-3t.paypal.com/nvp') {
     $host = 'https://www.paypal.com/cgi-bin/webscr';
@@ -76,15 +73,27 @@ function uc_paypal_ipn() {
     $host = variable_get('uc_paypal_wps_server', 'https://www.sandbox.paypal.com/cgi-bin/webscr');
   }
 
-  $response = drupal_http_request($host, array(), 'POST', $req);
+  // Setup the cURL request.
+  $ch = curl_init();
+  curl_setopt($ch, CURLOPT_URL, $host);
+  curl_setopt($ch, CURLOPT_VERBOSE, 0);
+  curl_setopt($ch, CURLOPT_POST, 1);
+  curl_setopt($ch, CURLOPT_POSTFIELDS, implode('&', $post_fields));
+  curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+  curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, 1);
+  curl_setopt($ch, CURLOPT_NOPROGRESS, 1);
+  curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 0);
+  $response = curl_exec($ch);
 
-  // TODO: Change this to property_exists when we have a PHP requirement >= 5.1.
-  if (array_key_exists('error', $response)) {
-    watchdog('uc_paypal', 'IPN failed with HTTP error @error, code @code.', array('@error' => $response->error, '@code' => $response->code), WATCHDOG_ERROR);
+  // Log any errors to the watchdog.
+  if ($error = curl_error($ch)) {
+    watchdog('uc_paypal', 'IPN failed with cURL error: @error', array('@error' => $error), WATCHDOG_ERROR);
     return;
   }
 
-  if (strcmp($response->data, 'VERIFIED') == 0) {
+  curl_close($ch);
+
+  if (strcmp($response, 'VERIFIED') == 0) {
     watchdog('uc_paypal', 'IPN transaction verified.');
 
     $duplicate = db_result(db_query("SELECT COUNT(*) FROM {uc_payment_paypal_ipn} WHERE txn_id = '%s' AND status <> 'Pending'", $txn_id));
@@ -158,7 +167,7 @@ function uc_paypal_ipn() {
         break;
     }
   }
-  elseif (strcmp($response->data, 'INVALID') == 0) {
+  elseif (strcmp($response, 'INVALID') == 0) {
     watchdog('uc_paypal', 'IPN transaction failed verification.', array(), WATCHDOG_ERROR);
     uc_order_comment_save($order_id, 0, t('An IPN transaction failed verification for this order.'), 'admin');
   }


### PR DESCRIPTION
PayPal IPN is broken in D6.

It was fixed in D7 by the following:

Issue [#2790197 - IPN error](https://www.drupal.org/project/ubercart/issues/2790197)
2016-12-30 - commit: [9c1fe65fe872f6b3e82c3b78d7c0d6872af407c2](https://git.drupalcode.org/project/ubercart/commit/9c1fe65fe872f6b3e82c3b78d7c0d6872af407c2)

Issue [#2800003 - New Paypal IPN address for HTTPS](https://www.drupal.org/project/ubercart/issues/2800003)
2018-01-24 - commit: [cf3ed00c3bc093ffaf10e7e90a757fe1a929d23a](https://git.drupalcode.org/project/ubercart/-/commit/cf3ed00c3bc093ffaf10e7e90a757fe1a929d23a)

I have cherry-picked these commits, and it seems to fix the issue.