### PR TITLE
Calling mktime() without arguments is deprecated

### DIFF
--- a/payment/uc_payment/uc_payment.admin.inc
+++ b/payment/uc_payment/uc_payment.admin.inc
@@ -492,7 +492,7 @@ function uc_payment_by_order_form_submit($form, &$form_state) {
   $startofday = mktime(0, 0, 0);
 
   if ($received == $startofday) {
-    $received = mktime();
+    $received = time();
   }
 
   uc_payment_enter($form_state['values']['order_id'], $payment['method'], $payment['amount'], $user->uid, '', $payment['comment'], $received);


### PR DESCRIPTION
Calling mktime() without arguments is deprecated. time() can be used to get the current timestamp. https://www.php.net/manual/en/function.mktime.php